### PR TITLE
Add GameMode Support (iOS 18+)

### DIFF
--- a/Source/iOS/App/DolphiniOS/Info.plist
+++ b/Source/iOS/App/DolphiniOS/Info.plist
@@ -6,6 +6,8 @@
 	<string>NotSet</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+  <key>GCSupportsGameMode</key>
+  <true/>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This addition to the info.plist allows DolphiniOS to be in game mode in iOS 18+.